### PR TITLE
make memory.h self contained

### DIFF
--- a/src/include/qmkl/memory.h
+++ b/src/include/qmkl/memory.h
@@ -11,6 +11,7 @@
 #define _QMKL_MEMORY_H_
 
 #include <sys/types.h>
+#include "qmkl/types.h"
 
 	void memory_init();
 	void memory_finalize();


### PR DESCRIPTION
`MKL_UINT` is unknown ident. without include `qmkl/types.h`