### PR TITLE
sgemm unit test using CUnit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,14 @@ add_subdirectory (src)
 add_subdirectory (test)
 
 enable_testing()
-add_test(sgemm sudo ./test/sgemm)
+
+include (cmake/FindCUnit.cmake)
+
+if(CUNIT_FOUND)
+add_test(sgemm_spec sudo ./test/sgemm_spec)
 add_custom_target(
 	check
 	COMMAND ${CMAKE_CTEST_COMMAND}
-	DEPENDS sgemm
+	DEPENDS sgemm_spec
 )
+endif(CUNIT_FOUND)

--- a/cmake/FindCUnit.cmake
+++ b/cmake/FindCUnit.cmake
@@ -1,0 +1,15 @@
+find_path(CUNIT_INCLUDE_DIR NAMES CUnit/CUnit.h)
+mark_as_advanced(CUNIT_INCLUDE_DIR)
+
+find_library(CUNIT_LIBRARY
+	NAMES cunit libcunit cunitlib
+)
+mark_as_advanced(CUNIT_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUnit DEFAULT_MSG CUNIT_LIBRARY CUNIT_INCLUDE_DIR)
+
+if(CUNIT_FOUND)
+	set(CUNIT_LIBRARIES ${CUNIT_LIBRARY})
+	set(CUNIT_INCLUDE_DIRS ${CUNIT_INCLUDE_DIR})
+endif(CUNIT_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,3 +42,16 @@ target_link_libraries (
 	vsAbs LINK_PUBLIC
 	qmkl
 )
+
+include (../cmake/FindCUnit.cmake)
+
+if(CUNIT_FOUND)
+add_executable (
+	sgemm_spec
+	sgemm_spec.c
+)
+target_link_libraries (
+	sgemm_spec
+	LINK_PUBLIC qmkl ${CUNIT_LIBRARIES}
+)
+endif(CUNIT_FOUND)

--- a/test/sgemm_spec.c
+++ b/test/sgemm_spec.c
@@ -1,0 +1,82 @@
+#include <unistd.h>
+#include <CUnit/Basic.h>
+#include <CUnit/Console.h>
+#include "mkl.h"
+
+static void suite_sgemm_RNN();
+
+int main() {
+    CU_initialize_registry();
+
+    suite_sgemm_RNN();
+
+    isatty(fileno(stdout)) ? CU_console_run_tests() : CU_basic_run_tests();
+    const unsigned int result = CU_get_number_of_failures();
+    CU_cleanup_registry();
+    return (result ? 1 : 0);
+}
+
+static void test_sgemm_RNN_ones_16x2_2x64();
+static void test_sgemm_RNN_ones_16x2_2x128();
+static void test_sgemm_RNN_ones_16x2_2x192();
+static void test_sgemm_RNN_ones_16x2_2x256();
+static void test_sgemm_RNN_ones_16x2_2x320();
+static void test_sgemm_RNN_ones_16x2_2x384();
+static void test_sgemm_RNN_ones_32x2_2x64 ();
+static void test_sgemm_RNN_ones_32x2_2x128();
+static void test_sgemm_RNN_ones_32x2_2x192();
+static void test_sgemm_RNN_ones_32x2_2x256();
+static void test_sgemm_RNN_ones_32x2_2x320();
+static void test_sgemm_RNN_ones_32x2_2x384();
+
+void suite_sgemm_RNN() {
+    CU_pSuite suite = CU_add_suite("sgemm RNN", NULL, NULL);
+    CU_add_test(suite, "ones 16x2 * 2x64" , test_sgemm_RNN_ones_16x2_2x64 );
+    CU_add_test(suite, "ones 16x2 * 2x128", test_sgemm_RNN_ones_16x2_2x128);
+    CU_add_test(suite, "ones 16x2 * 2x192", test_sgemm_RNN_ones_16x2_2x192);
+    CU_add_test(suite, "ones 16x2 * 2x256", test_sgemm_RNN_ones_16x2_2x256);
+    CU_add_test(suite, "ones 16x2 * 2x320", test_sgemm_RNN_ones_16x2_2x320);
+    CU_add_test(suite, "ones 16x2 * 2x384", test_sgemm_RNN_ones_16x2_2x384);
+    CU_add_test(suite, "ones 32x2 * 2x64" , test_sgemm_RNN_ones_32x2_2x64 );
+    CU_add_test(suite, "ones 32x2 * 2x128", test_sgemm_RNN_ones_32x2_2x128);
+    CU_add_test(suite, "ones 32x2 * 2x192", test_sgemm_RNN_ones_32x2_2x192);
+    CU_add_test(suite, "ones 32x2 * 2x256", test_sgemm_RNN_ones_32x2_2x256);
+    CU_add_test(suite, "ones 32x2 * 2x320", test_sgemm_RNN_ones_32x2_2x320);
+    CU_add_test(suite, "ones 32x2 * 2x384", test_sgemm_RNN_ones_32x2_2x384);
+}
+
+static float* mkl_malloc_ones(const int m, const int n) {
+    float* p = mkl_malloc(m * n * sizeof(float), 4096);
+    int i = 0;
+    for (i = 0; i < m * n; ++i) p[i] = 1.0;
+    return p;
+}
+
+static void test_sgemm_RNN_ones(const int M, const int N, const int K) {
+    float* A = mkl_malloc_ones(M, K);
+    float* B = mkl_malloc_ones(K, N);
+    float* C = mkl_malloc_ones(M, N);
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, M, N, K, 1, A, K, B, N, 1, C, N);
+    {
+        int i, j;
+        for (i = 0; i < M; ++i)
+            for (j = 0; j < N; ++j)
+                CU_ASSERT_EQUAL(K+1, (int)C[i*N+j]);
+    }
+    mkl_free(C);
+	mkl_free(B);
+	mkl_free(A);
+}
+
+void test_sgemm_RNN_ones_16x2_2x64()  { test_sgemm_RNN_ones(16,  64, 2); }
+void test_sgemm_RNN_ones_16x2_2x128() { test_sgemm_RNN_ones(16, 128, 2); }
+void test_sgemm_RNN_ones_16x2_2x192() { test_sgemm_RNN_ones(16, 192, 2); }
+void test_sgemm_RNN_ones_16x2_2x256() { test_sgemm_RNN_ones(16, 256, 2); }
+void test_sgemm_RNN_ones_16x2_2x320() { test_sgemm_RNN_ones(16, 320, 2); }
+void test_sgemm_RNN_ones_16x2_2x384() { test_sgemm_RNN_ones(16, 384, 2); }
+void test_sgemm_RNN_ones_32x2_2x64 () { test_sgemm_RNN_ones(32,  64, 2); }
+void test_sgemm_RNN_ones_32x2_2x128() { test_sgemm_RNN_ones(32, 128, 2); }
+void test_sgemm_RNN_ones_32x2_2x192() { test_sgemm_RNN_ones(32, 192, 2); }
+void test_sgemm_RNN_ones_32x2_2x256() { test_sgemm_RNN_ones(32, 256, 2); }
+void test_sgemm_RNN_ones_32x2_2x320() { test_sgemm_RNN_ones(32, 320, 2); }
+void test_sgemm_RNN_ones_32x2_2x384() { test_sgemm_RNN_ones(32, 384, 2); }


### PR DESCRIPTION
This PR
- add sgemm_spec executable which is a unit test for sgemm uging CUnit test framework.
- change `make test` (and `make check`) target from sgemm to sgemm_spec.
- skip build & run sgemm_spec if CUnit is not found in your system.
