### PR TITLE
Add invalidate_cpu_l2c function

### DIFF
--- a/test/memory_bench.c
+++ b/test/memory_bench.c
@@ -24,7 +24,7 @@ static void invalidate_cpu_l2c()
     const int NLOOPS = 10;
     size_t j;
     const size_t SIZE = 16 * 1024 * 1024;
-    int *p = host_malloc(SIZE);
+    int * volatile p = host_malloc(SIZE);
     const size_t LEN = SIZE / sizeof(*p);
     for (i = 0; i < NLOOPS; i ++) {
         p[LEN - 1] = p[0];


### PR DESCRIPTION
Add `invalidate_cpu_l2c` function which invalidates CPU-unified L2C.

Note that current `N` is large enough to be spilled from L2C. Use of `incalidate_cpu_l2c` function is only needed for smaller `N`.