### PR TITLE
test/sgemm: Use Gaussian random numbers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable (
 )
 target_link_libraries (
     sgemm LINK_PUBLIC
-    qmkl
+    m qmkl
 )
 
 add_executable (


### PR DESCRIPTION
py-videocore's sgemm uses Gaussian random numbers to initialize matrices. To do the same in QMKL, we can now estimate that the errors are sane or not.

c.f. https://github.com/nineties/py-videocore/issues/5